### PR TITLE
feat: [Diary] 페이지 작성 시 완료여부 확인

### DIFF
--- a/spring-boot/src/main/java/com/tody/dayori/diary/domain/Diary.java
+++ b/spring-boot/src/main/java/com/tody/dayori/diary/domain/Diary.java
@@ -51,6 +51,9 @@ public class Diary extends BaseEntity{
     @Column(nullable = false)
     private Long diaryWriter;
 
+    @Column(nullable = false)
+    private Boolean nextAble;
+
     @OneToMany(mappedBy = "diary")
     private List<UserDiary> userDiaryList = new ArrayList<>();
 
@@ -64,6 +67,7 @@ public class Diary extends BaseEntity{
         diary.diaryWithdraw = false;
         diary.invitationCode = "";
         diary.diaryWriter = userSeq;
+        diary.nextAble = false;
         return diary;
     }
 
@@ -78,6 +82,7 @@ public class Diary extends BaseEntity{
 
     public void updateWriter(Long userSeq) {
         this.diaryWriter = userSeq;
+        this.nextAble = false;
     }
 
 }

--- a/spring-boot/src/main/java/com/tody/dayori/diary/service/DiaryServiceImpl.java
+++ b/spring-boot/src/main/java/com/tody/dayori/diary/service/DiaryServiceImpl.java
@@ -122,17 +122,19 @@ public class DiaryServiceImpl implements DiaryService{
         for (Diary diary : diaries) {
             int duration = diary.getDiaryDuration();
             Long Writer = diary.getDiaryWriter();
-            LocalDateTime createDiaryDate = diary.getDiaryCreateAt();
-            LocalDateTime currentDate = LocalDateTime.now();
-//            Long daysPassed = ChronoUnit.DAYS.between(createDiaryDate, currentDate);
-            Long daysPassed = ChronoUnit.MINUTES.between(createDiaryDate, currentDate);
+            Boolean nextAble = diary.getNextAble();
             User nowUser = userRepository.findById(Writer).orElseThrow(EntityNotFoundException::new);
 
             if (duration > 0) {
-                if (duration == 1) {
-                    // duration이 1인 경우 항상 실행
+                if (duration == 1 || nextAble) {
+                    // duration 이 1인 경우 항상 실행 || duration 상관 없이 nextAble 이 true 면 차례 넘김
                     diary.updateWriter(WhoIsNext(nowUser, diary));
                 } else {
+                    LocalDateTime createDiaryDate = diary.getDiaryCreateAt();
+                    LocalDateTime currentDate = LocalDateTime.now();
+//                  Long daysPassed = ChronoUnit.DAYS.between(createDiaryDate, currentDate);
+                    Long daysPassed = ChronoUnit.MINUTES.between(createDiaryDate, currentDate);
+
                     if (daysPassed % duration == 0) {
                         diary.updateWriter(WhoIsNext(nowUser, diary));
                     }


### PR DESCRIPTION
close #29 

## 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 페이지 작성 완료를 확인하기 위한 nextAble(Boolean)속성 다이어리 테이블에 생성
- 초기 다이어리 생성 시 nextAble = false
- nextAble = true이면 duration 관계 없이 차례 넘어감.
- 차례가 넘어가면 nextAble = false로 업데이트
- ⭐⭐⭐페이지 작성 시 해당 다이어리의 nextAble 속성 true로 업데이트 하는 로직 필요⭐⭐⭐

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
